### PR TITLE
rc: cross-OS clipboard wrapper, fzf.fish-style Ctrl+R/V, zz abbr

### DIFF
--- a/bin/zellij-copy-command
+++ b/bin/zellij-copy-command
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Cross-OS clipboard writer for zellij's copy_command.
+# Reads stdin (UTF-8 selected text) and writes to the system clipboard
+# preserving the encoding — clip.exe on Korean Windows mangles UTF-8 to
+# CP949, so route through PowerShell's Set-Clipboard instead.
+
+set -eu
+
+case "$(uname -s)" in
+    Linux*)
+        if command -v wl-copy >/dev/null 2>&1; then
+            wl-copy
+        else
+            xclip -selection clipboard
+        fi
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        # Force UTF-8 stdin so non-ASCII (e.g. Hangul) survives instead of
+        # being decoded as the system ANSI codepage (CP949 on Korean Windows).
+        powershell.exe -NoProfile -Command '[Console]::InputEncoding=[System.Text.Encoding]::UTF8; Set-Clipboard -Value ([Console]::In.ReadToEnd())'
+        ;;
+    Darwin*)
+        pbcopy
+        ;;
+esac

--- a/config/zellij.kdl
+++ b/config/zellij.kdl
@@ -390,8 +390,13 @@ theme "pencil-light-edited"
 // that will be used by default if this option is not set.
 // Examples:
 //
+// Cross-OS wrapper at lens0021/lens0021-provision/bin/zellij-copy-command
+// dispatches to wl-copy / xclip / Set-Clipboard / pbcopy by uname -s.
+// Requires the bin dir on PATH (set in shell rc).
+copy_command "bash zellij-copy-command"
+// Per-OS originals (kept for reference):
 // copy_command "xclip -selection clipboard" // x11
-copy_command "wl-copy"                    // wayland
+// copy_command "wl-copy"                    // wayland
 // copy_command "pbcopy"                     // osx
 
 // Choose the destination for copied text

--- a/rc/rc.bash
+++ b/rc/rc.bash
@@ -36,8 +36,7 @@ if [ -d ~/.bashrc.d ]; then
 fi
 unset rc
 
-[ -f "$HOME/.fzf.bash" ] && source "$HOME/.fzf.bash"
-[ -f /usr/local/git/port/user-leslie-snippets/rc/rc.sh ] && source /usr/local/git/port/user-leslie-snippets/rc/rc.sh
+[ -f ~/git/port/leslie-kit/rc/rc.bash ] && source ~/git/port/leslie-kit/rc/rc.bash
 [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
 
 # User specific aliases
@@ -55,3 +54,59 @@ fi
 complete -C /home/nemo/.terraform.versions/terraform_1.6.5 terraform
 
 complete -C /usr/bin/tofu tofu
+
+# fzf.fish-style key bindings (interactive only — `bind` errors out
+# in non-interactive shells with "line editing not enabled").
+
+# Ctrl+R — history search. Sorted by recency, dedup, toggle-sort with Ctrl+R.
+__lens_fzf_history__() {
+    local out
+    out=$(
+        builtin history | sed 's/^[ ]*[0-9]\+[ ]*//' | awk '!seen[$0]++' | tac \
+        | fzf --height 100% --reverse \
+              --prompt="History> " \
+              --scheme=history --no-sort --tiebreak=index \
+              --bind=ctrl-r:toggle-sort \
+              --preview='printf %s {}' \
+              --preview-window=down:3:wrap \
+              --query="$READLINE_LINE"
+    ) || return
+    READLINE_LINE="$out"
+    READLINE_POINT=${#out}
+}
+if [[ $- == *i* ]]; then
+bind -x '"\C-r": __lens_fzf_history__'
+
+# Ctrl+V — file picker, inserts path at cursor. fd + bat (fallback find/cat).
+__lens_fzf_files__() {
+    local preview cmd selected
+    if command -v bat >/dev/null; then
+        preview='bat --style=numbers --color=always --line-range :200 {}'
+    else
+        preview='cat {}'
+    fi
+    if command -v fd >/dev/null; then
+        cmd='fd --hidden --exclude .git --type f'
+    else
+        cmd='find . -type f -not -path "*/.git/*"'
+    fi
+    selected=$(eval "$cmd" | fzf \
+        --height 100% --reverse \
+        --prompt="Files> " \
+        --preview="$preview" \
+        --preview-window=right:60%:wrap) || return
+    READLINE_LINE="${READLINE_LINE:0:READLINE_POINT}$selected${READLINE_LINE:READLINE_POINT}"
+    READLINE_POINT=$((READLINE_POINT + ${#selected}))
+}
+# Ctrl+V: stty's lnext (default ^V) intercepts at the terminal driver
+# layer before bash readline sees it, so `bind -x` alone can't override.
+# Disable lnext so the keypress reaches readline, then point it at our fn.
+stty lnext undef 2>/dev/null
+bind -r '"\C-v"' 2>/dev/null
+bind -x '"\C-v": __lens_fzf_files__'
+fi  # interactive
+
+# fish-style abbreviations (relies on abbrev-alias plugin sourced earlier).
+if [[ $- == *i* ]] && type abbrev-alias >/dev/null 2>&1; then
+    abbrev-alias zz='z $(zoxide query -i)'
+fi


### PR DESCRIPTION
Stacked on top of #2.

`bin/zellij-copy-command` (new): tiny bash wrapper that dispatches to `wl-copy` / `xclip` / `Set-Clipboard` / `pbcopy` by `uname -s`. Solves Korean mojibake on Windows where `clip.exe` re-decodes UTF-8 stdin as CP949; PowerShell's `Set-Clipboard` handles the encoding correctly.

`config/zellij.kdl`: `copy_command` now points at the wrapper. Both Linux (wl-copy fallback) and Windows can share this single config; the bin dir goes on `\$PATH` via the shell rc.

`rc/rc.bash`:

- Drop the legacy `~/.fzf.bash` source — it brought Ctrl+T which collides with the user's zellij keybind.
- Replace stale `user-leslie-snippets/rc/rc.sh` source with the current path `~/git/port/leslie-kit/rc/rc.bash`.
- Ctrl+R: full-screen fzf history with toggle-sort and a preview pane, matching the fzf.fish look.
- Ctrl+V: file picker (fd + bat fallback), inserts path at cursor. Disable stty's `lnext` so the keypress reaches readline; without this the terminal driver eats `^V` before `bind -x` can fire.
- `zz` abbr: `z \$(zoxide query -i)` — mirrors the fish abbr from `lens0021_personal.fish`, expands inline via bash-abbrev-alias.
- Guard `bind` / `abbrev-alias` calls with `[[ \$- == *i* ]]` so non-interactive bash invocations stay quiet.