### PR TITLE
config/sheldon: declare bash-abbrev-alias for non-Windows

### DIFF
--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -1,0 +1,14 @@
+# sheldon plugin manifest. Used as the plugins.toml hardlink target on
+# Windows (and any other host that wires sheldon up). Apply:
+#
+#   eval "$(sheldon source)"   # sourced from ~/.bashrc
+#
+# https://sheldon.cli.rs/
+
+shell = "bash"
+
+[plugins]
+
+[plugins.bash-abbrev-alias]
+github = "momo-lab/bash-abbrev-alias"
+use = ["{{ name }}.plugin.bash"]


### PR DESCRIPTION
Single-file PR introducing \`config/sheldon/plugins.toml\` so Linux and macOS can use [sheldon](https://sheldon.cli.rs/) as the canonical shell plugin manager. Currently lists one plugin (\`momo-lab/bash-abbrev-alias\`); future entries land here.

## Why Windows is excluded

sheldon 0.8.5 (latest, cargo-built) fails on Windows native with:

\`\`\`
ERROR: failed to acquire lock on config directory
  due to: failed to open \`C:/Users/.../.config/sheldon\`
  due to: 액세스가 거부되었습니다. (os error 5)
\`\`\`

sheldon opens the config directory as a file handle for advisory locking, which Windows does not permit. Reproduces with multiple \`SHELDON_CONFIG_DIR\` paths and is unrelated to ACLs. There are no pre-built Windows binaries either.

Windows therefore keeps the existing ad-hoc \`git clone\` of \`bash-abbrev-alias\` inside \`windows/bootstrap.ps1\` (Section A). When upstream sheldon addresses the directory lock — or a fork lands — Windows can switch over.

## Linux / macOS hookup (out of scope here)

To consume this manifest on Linux/macOS, add to the shell rc:

\`\`\`bash
[[ \$- == *i* ]] && command -v sheldon >/dev/null && eval "\$(sheldon source)"
\`\`\`

That wiring is left to a follow-up PR per platform.