### PR TITLE
windows: rich Tab completion via carapace + fzf-tab-completion

### DIFF
--- a/windows/bootstrap.ps1
+++ b/windows/bootstrap.ps1
@@ -31,6 +31,7 @@ $packages = @(
     'Starship.Starship'            # cross-shell prompt
     'AltSnap.AltSnap'              # Super+drag to move windows (GNOME-style)
     'AutoHotkey.AutoHotkey'        # keyboard scripting (Win-key shortcuts)
+    'rsteube.Carapace'             # multi-shell completion engine (bash menu)
     'GitHub.cli'
     'GLab.GLab'
     'Helix.Helix'
@@ -158,6 +159,19 @@ if (Test-Path "$abbrDir\abbrev-alias.plugin.bash") {
     $parent = Split-Path -Parent $abbrDir
     if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
     & git clone https://github.com/momo-lab/bash-abbrev-alias.git $abbrDir
+}
+
+# fzf-tab-completion — replaces bash's plain Tab menu with an fzf picker.
+# Pairs with carapace below: carapace generates rich candidate data,
+# fzf-tab-completion renders the menu UI.
+$fzfTabDir = Join-Path $env:USERPROFILE '.local\share\fzf-tab-completion'
+if (Test-Path "$fzfTabDir\bash\fzf-bash-completion.sh") {
+    Write-Host '[skip]    fzf-tab-completion'
+} else {
+    Write-Host '[install] fzf-tab-completion'
+    $parent = Split-Path -Parent $fzfTabDir
+    if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
+    & git clone --depth 1 https://github.com/lincheney/fzf-tab-completion.git $fzfTabDir
 }
 
 # DebugView (Sysinternals) — winget manifest is broken (no installer URL),
@@ -732,6 +746,23 @@ export COLORTERM=truecolor
 # which spams "line editing not enabled" warnings in non-interactive shells.
 [[ $- == *i* && -f ~/.local/share/bash-abbrev-alias/abbrev-alias.plugin.bash ]] && \
     source ~/.local/share/bash-abbrev-alias/abbrev-alias.plugin.bash
+
+# carapace: rich completion data (icons + descriptions + flag hints across
+# hundreds of CLIs). The data is consumed by bash's complete -F machinery.
+[[ $- == *i* ]] && command -v carapace >/dev/null && source <(carapace _carapace bash)
+
+# fzf-tab-completion: replaces bash's "Display all 45 possibilities?"
+# prompt with an fzf picker. Pairs with carapace — carapace populates
+# the candidate list, fzf-tab-completion renders the menu.
+#
+# FZF_TMUX_HEIGHT skips the cursor-position DSR query (\e[6n) that
+# fzf-bash-completion.sh otherwise issues; the response isn't forwarded
+# through Git Bash's MSYS PTY and bash hangs waiting for it on Windows.
+if [[ $- == *i* ]] && [ -f ~/.local/share/fzf-tab-completion/bash/fzf-bash-completion.sh ]; then
+    export FZF_TMUX_HEIGHT="${FZF_TMUX_HEIGHT:-40%}"
+    source ~/.local/share/fzf-tab-completion/bash/fzf-bash-completion.sh
+    bind -x '"\t": fzf_bash_completion'
+fi
 
 # yazi: y wrapper that cds into yazi-exited dir.
 # winpty wraps native Windows TUIs in Git Bash so they get a proper PTY —


### PR DESCRIPTION
bash readline's default Tab UI is plain ("Display all 45 possibilities? y/n"). To get an IDE-style fuzzy menu like fish/zsh on Git Bash, two cooperating pieces are needed:

- **[carapace-bin](https://github.com/carapace-sh/carapace-bin)** (Go single binary, on winget as \`rsteube.Carapace\`): generates rich candidate data (icons, descriptions, flag hints) for hundreds of CLIs.
- **[lincheney/fzf-tab-completion](https://github.com/lincheney/fzf-tab-completion)**: intercepts Tab via \`bind -x\`, runs bash's existing completion (which now includes carapace), and pipes candidates through fzf as the menu UI.

## bootstrap.ps1 changes

**Section A** (packages):

- Install \`rsteube.Carapace\` via winget.
- Clone fzf-tab-completion into \`~/.local/share/fzf-tab-completion\` alongside bash-abbrev-alias.

**Section C** (bashrc snippet):

\`\`\`bash
[[ \$- == *i* ]] && command -v carapace >/dev/null && source <(carapace _carapace bash)

if [[ \$- == *i* ]] && [ -f ~/.local/share/fzf-tab-completion/bash/fzf-bash-completion.sh ]; then
    export FZF_TMUX_HEIGHT="\${FZF_TMUX_HEIGHT:-40%}"
    source ~/.local/share/fzf-tab-completion/bash/fzf-bash-completion.sh
    bind -x '"\t": fzf_bash_completion'
fi
\`\`\`

\`FZF_TMUX_HEIGHT\` is the key Windows fix: it skips a DSR cursor-position query (\`\e[6n\`) that fzf-bash-completion.sh otherwise issues. The response isn't forwarded through Git Bash's MSYS PTY and bash hangs waiting for it.

## Why not alternatives

- **inshellisense**: archived, npm-only, requires Node.js runtime.
- **Amazon Q**: macOS / Linux only, no Windows native.
- **ble.sh**: full readline replacement, conflicts with our existing \`bind -x\` keymaps for Ctrl+R / Ctrl+V.
- **carapace alone**: provides richer data but bash readline still shows the plain "45 possibilities?" prompt — no UX improvement.

## Performance note

Each Tab press takes ~750 ms on Git Bash. fzf-bash-completion.sh implements a mini shell parser entirely in awk/sed/grep — ~15 subprocess spawns per call, and MSYS process spawn is ~50 ms (vs. ~5 ms on Linux). Acceptable for the UX gain; users on Linux see ~75 ms and don't notice.

## Live ~/.bashrc

This PR only updates the bootstrap-generated snippet for fresh provisions. To pick up the change on the current machine without re-running bootstrap, manually append the carapace + fzf-tab-completion lines to \`~/.bashrc\`.