### PR TITLE
ahk: Ctrl+Win+<n> launches a new pinned-app instance (GNOME-style)

### DIFF
--- a/config/ahk/keys.ahk
+++ b/config/ahk/keys.ahk
@@ -4,3 +4,17 @@
 ; Volume control via Ctrl+Win+Arrow.
 ^#Up::Send "{Volume_Up}"
 ^#Down::Send "{Volume_Down}"
+
+; Launch a new instance of the Nth pinned taskbar app (GNOME-style).
+; Windows native: Shift+Win+<n> → new instance, Ctrl+Win+<n> → switch
+; to last active window. GNOME muscle memory uses Ctrl+Super+<n> for
+; "new instance"; rebind Ctrl+Win+<n> to Shift+Win+<n> to match.
+^#1::Send "+#1"
+^#2::Send "+#2"
+^#3::Send "+#3"
+^#4::Send "+#4"
+^#5::Send "+#5"
+^#6::Send "+#6"
+^#7::Send "+#7"
+^#8::Send "+#8"
+^#9::Send "+#9"


### PR DESCRIPTION
Rebinds `Ctrl+Win+1..9` to Windows' native `Shift+Win+1..9` (new instance of the Nth pinned taskbar app), matching the GNOME shortcut for the same action.

`Ctrl+Win+<n>` on Windows native maps to "switch to last active window" — different from GNOME's "new instance". This rebind aligns with muscle memory.

PowerToys Keyboard Manager would have been the obvious tool, but it doesn't reliably intercept Win-key chords (the shell handles them first). AHK's low-level keyboard hook does.